### PR TITLE
Attribute rules: added numeric >, <, >=, <= operators

### DIFF
--- a/backend/functional/features/check.feature
+++ b/backend/functional/features/check.feature
@@ -154,6 +154,7 @@ Feature: check
         "kind": "post",
         "value": "789",
         "attributes": [
+          {"key": "owner_id", "value": "owner-123"},
           {"key": "is_editable", "value": true}
         ]
       }
@@ -192,6 +193,7 @@ Feature: check
         "kind": "post",
         "value": "10-updated-after",
         "attributes": [
+          {"key": "owner_id", "value": "owner-123"},
           {"key": "is_editable", "value": true}
         ]
       }
@@ -274,6 +276,256 @@ Feature: check
             "resource_value": "10-updated-after",
             "action": "create",
             "is_allowed": true
+          }
+        ]
+      }
+      """
+
+  Scenario: Check for access (using ABAC greater operator)
+    Given I authenticate with username "admin" and password "changeme"
+    And I send "POST" request to "/v1/resources" with payload:
+      """
+      {
+        "id": "post.123",
+        "kind": "post",
+        "value": "123",
+        "attributes": [
+          {"key": "number", "value": 10}
+        ]
+      }
+      """
+    And the response code should be 200
+    And I send "POST" request to "/v1/resources" with payload:
+      """
+      {
+        "id": "post.456",
+        "kind": "post",
+        "value": "456",
+        "attributes": [
+          {"key": "number", "value": 20}
+        ]
+      }
+      """
+    And the response code should be 200
+    And I send "POST" request to "/v1/resources" with payload:
+      """
+      {
+        "id": "post.789",
+        "kind": "post",
+        "value": "789"
+      }
+      """
+    And the response code should be 200
+    And I send "POST" request to "/v1/principals" with payload:
+      """
+      {
+        "id": "my-principal"
+      }
+      """
+    And the response code should be 200
+    And I send "POST" request to "/v1/policies" with payload:
+      """
+      {
+        "id": "my-post-greater-10",
+        "resources": [
+            "post.*"
+        ],
+        "actions": ["create"],
+        "attribute_rules": [
+          "resource.number > 10"
+        ]
+      }
+      """
+    And the response code should be 200
+    And I wait "1s"
+    When I send "POST" request to "/v1/check" with payload:
+      """
+      {
+        "checks": [
+          {
+            "principal": "my-principal",
+            "resource_kind": "post",
+            "resource_value": "123",
+            "action": "create"
+          },
+          {
+            "principal": "my-principal",
+            "resource_kind": "post",
+            "resource_value": "123",
+            "action": "update"
+          },
+          {
+            "principal": "my-principal",
+            "resource_kind": "post",
+            "resource_value": "456",
+            "action": "create"
+          },
+          {
+            "principal": "my-principal",
+            "resource_kind": "post",
+            "resource_value": "789",
+            "action": "create"
+          }
+        ]
+      }
+      """
+    And the response code should be 200
+    And the response should match json:
+      """
+      {
+        "checks": [
+          {
+            "principal": "my-principal",
+            "resource_kind": "post",
+            "resource_value": "123",
+            "action": "create",
+            "is_allowed": false
+          },
+          {
+            "principal": "my-principal",
+            "resource_kind": "post",
+            "resource_value": "123",
+            "action": "update",
+            "is_allowed": false
+          },
+          {
+            "principal": "my-principal",
+            "resource_kind": "post",
+            "resource_value": "456",
+            "action": "create",
+            "is_allowed": true
+          },
+          {
+            "principal": "my-principal",
+            "resource_kind": "post",
+            "resource_value": "789",
+            "action": "create",
+            "is_allowed": false
+          }
+        ]
+      }
+      """
+
+  Scenario: Check for access (using ABAC lower operator)
+    Given I authenticate with username "admin" and password "changeme"
+    And I send "POST" request to "/v1/resources" with payload:
+      """
+      {
+        "id": "post.123",
+        "kind": "post",
+        "value": "123",
+        "attributes": [
+          {"key": "number", "value": 10}
+        ]
+      }
+      """
+    And the response code should be 200
+    And I send "POST" request to "/v1/resources" with payload:
+      """
+      {
+        "id": "post.456",
+        "kind": "post",
+        "value": "456",
+        "attributes": [
+          {"key": "number", "value": 20}
+        ]
+      }
+      """
+    And the response code should be 200
+    And I send "POST" request to "/v1/resources" with payload:
+      """
+      {
+        "id": "post.789",
+        "kind": "post",
+        "value": "789"
+      }
+      """
+    And the response code should be 200
+    And I send "POST" request to "/v1/principals" with payload:
+      """
+      {
+        "id": "my-principal"
+      }
+      """
+    And the response code should be 200
+    And I send "POST" request to "/v1/policies" with payload:
+      """
+      {
+        "id": "my-post-greater-10",
+        "resources": [
+            "post.*"
+        ],
+        "actions": ["create"],
+        "attribute_rules": [
+          "resource.number < 20"
+        ]
+      }
+      """
+    And the response code should be 200
+    And I wait "1s"
+    When I send "POST" request to "/v1/check" with payload:
+      """
+      {
+        "checks": [
+          {
+            "principal": "my-principal",
+            "resource_kind": "post",
+            "resource_value": "123",
+            "action": "create"
+          },
+          {
+            "principal": "my-principal",
+            "resource_kind": "post",
+            "resource_value": "123",
+            "action": "update"
+          },
+          {
+            "principal": "my-principal",
+            "resource_kind": "post",
+            "resource_value": "456",
+            "action": "create"
+          },
+          {
+            "principal": "my-principal",
+            "resource_kind": "post",
+            "resource_value": "789",
+            "action": "create"
+          }
+        ]
+      }
+      """
+    And the response code should be 200
+    And the response should match json:
+      """
+      {
+        "checks": [
+          {
+            "principal": "my-principal",
+            "resource_kind": "post",
+            "resource_value": "123",
+            "action": "create",
+            "is_allowed": true
+          },
+          {
+            "principal": "my-principal",
+            "resource_kind": "post",
+            "resource_value": "123",
+            "action": "update",
+            "is_allowed": false
+          },
+          {
+            "principal": "my-principal",
+            "resource_kind": "post",
+            "resource_value": "456",
+            "action": "create",
+            "is_allowed": false
+          },
+          {
+            "principal": "my-principal",
+            "resource_kind": "post",
+            "resource_value": "789",
+            "action": "create",
+            "is_allowed": false
           }
         ]
       }

--- a/backend/internal/attribute/rule_test.go
+++ b/backend/internal/attribute/rule_test.go
@@ -3,8 +3,249 @@ package attribute
 import (
 	"testing"
 
+	"github.com/eko/authz/backend/internal/entity/model"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestRule_MatchPrincipal(t *testing.T) {
+	// Given
+	testCases := []struct {
+		name       string
+		attributes model.Attributes
+		rule       *Rule
+		expected   bool
+	}{
+		{
+			name:       "Empty attributes and rules",
+			attributes: model.Attributes{},
+			rule:       &Rule{},
+			expected:   true,
+		},
+		{
+			name: "Attributes matching > rule",
+			attributes: model.Attributes{
+				{Key: "my_attribute", Value: "50"},
+			},
+			rule: &Rule{
+				PrincipalAttribute: "my_attribute",
+				Operator:           RuleOperatorGreater,
+				Value:              "40",
+			},
+			expected: true,
+		},
+		{
+			name: "Attributes not matching >= rule when equal",
+			attributes: model.Attributes{
+				{Key: "my_attribute", Value: "50"},
+			},
+			rule: &Rule{
+				PrincipalAttribute: "my_attribute",
+				Operator:           RuleOperatorGreaterEqual,
+				Value:              "50",
+			},
+			expected: true,
+		},
+		{
+			name: "Attributes not matching >= rule when greater",
+			attributes: model.Attributes{
+				{Key: "my_attribute", Value: "51"},
+			},
+			rule: &Rule{
+				PrincipalAttribute: "my_attribute",
+				Operator:           RuleOperatorGreaterEqual,
+				Value:              "50",
+			},
+			expected: true,
+		},
+		{
+			name: "Attributes not matching > rule",
+			attributes: model.Attributes{
+				{Key: "my_attribute", Value: "50"},
+			},
+			rule: &Rule{
+				PrincipalAttribute: "my_attribute",
+				Operator:           RuleOperatorGreater,
+				Value:              "60",
+			},
+			expected: false,
+		},
+		{
+			name: "Attributes matching < rule",
+			attributes: model.Attributes{
+				{Key: "my_attribute", Value: "50"},
+			},
+			rule: &Rule{
+				PrincipalAttribute: "my_attribute",
+				Operator:           RuleOperatorLower,
+				Value:              "60",
+			},
+			expected: true,
+		},
+		{
+			name: "Attributes matching <= rule when equal",
+			attributes: model.Attributes{
+				{Key: "my_attribute", Value: "50"},
+			},
+			rule: &Rule{
+				PrincipalAttribute: "my_attribute",
+				Operator:           RuleOperatorLowerEqual,
+				Value:              "50",
+			},
+			expected: true,
+		},
+		{
+			name: "Attributes matching <= rule when lower",
+			attributes: model.Attributes{
+				{Key: "my_attribute", Value: "49"},
+			},
+			rule: &Rule{
+				PrincipalAttribute: "my_attribute",
+				Operator:           RuleOperatorLowerEqual,
+				Value:              "50",
+			},
+			expected: true,
+		},
+		{
+			name: "Attributes not matching < rule",
+			attributes: model.Attributes{
+				{Key: "my_attribute", Value: "50"},
+			},
+			rule: &Rule{
+				PrincipalAttribute: "my_attribute",
+				Operator:           RuleOperatorLower,
+				Value:              "40",
+			},
+			expected: false,
+		},
+	}
+
+	// When - Then
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, testCase.rule.MatchPrincipal(testCase.attributes))
+		})
+	}
+}
+
+func TestRule_MatchResource(t *testing.T) {
+	// Given
+	testCases := []struct {
+		name       string
+		attributes model.Attributes
+		rule       *Rule
+		expected   bool
+	}{
+		{
+			name:       "Empty attributes and rules",
+			attributes: model.Attributes{},
+			rule:       &Rule{},
+			expected:   true,
+		},
+		{
+			name: "Attributes matching > rule",
+			attributes: model.Attributes{
+				{Key: "my_attribute", Value: "50"},
+			},
+			rule: &Rule{
+				ResourceAttribute: "my_attribute",
+				Operator:          RuleOperatorGreater,
+				Value:             "40",
+			},
+			expected: true,
+		},
+		{
+			name: "Attributes not matching >= rule when equal",
+			attributes: model.Attributes{
+				{Key: "my_attribute", Value: "50"},
+			},
+			rule: &Rule{
+				ResourceAttribute: "my_attribute",
+				Operator:          RuleOperatorGreaterEqual,
+				Value:             "50",
+			},
+			expected: true,
+		},
+		{
+			name: "Attributes not matching >= rule when greater",
+			attributes: model.Attributes{
+				{Key: "my_attribute", Value: "51"},
+			},
+			rule: &Rule{
+				ResourceAttribute: "my_attribute",
+				Operator:          RuleOperatorGreaterEqual,
+				Value:             "50",
+			},
+			expected: true,
+		},
+		{
+			name: "Attributes not matching > rule",
+			attributes: model.Attributes{
+				{Key: "my_attribute", Value: "50"},
+			},
+			rule: &Rule{
+				ResourceAttribute: "my_attribute",
+				Operator:          RuleOperatorGreater,
+				Value:             "60",
+			},
+			expected: false,
+		},
+		{
+			name: "Attributes matching < rule",
+			attributes: model.Attributes{
+				{Key: "my_attribute", Value: "50"},
+			},
+			rule: &Rule{
+				ResourceAttribute: "my_attribute",
+				Operator:          RuleOperatorLower,
+				Value:             "60",
+			},
+			expected: true,
+		},
+		{
+			name: "Attributes matching <= rule when equal",
+			attributes: model.Attributes{
+				{Key: "my_attribute", Value: "50"},
+			},
+			rule: &Rule{
+				ResourceAttribute: "my_attribute",
+				Operator:          RuleOperatorLowerEqual,
+				Value:             "50",
+			},
+			expected: true,
+		},
+		{
+			name: "Attributes matching <= rule when lower",
+			attributes: model.Attributes{
+				{Key: "my_attribute", Value: "49"},
+			},
+			rule: &Rule{
+				ResourceAttribute: "my_attribute",
+				Operator:          RuleOperatorLowerEqual,
+				Value:             "50",
+			},
+			expected: true,
+		},
+		{
+			name: "Attributes not matching < rule",
+			attributes: model.Attributes{
+				{Key: "my_attribute", Value: "50"},
+			},
+			rule: &Rule{
+				ResourceAttribute: "my_attribute",
+				Operator:          RuleOperatorLower,
+				Value:             "40",
+			},
+			expected: false,
+		},
+	}
+
+	// When - Then
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, testCase.rule.MatchResource(testCase.attributes))
+		})
+	}
+}
 
 func TestConvertStringToRuleOperator(t *testing.T) {
 	testCases := []struct {

--- a/backend/internal/entity/model/attribute.go
+++ b/backend/internal/entity/model/attribute.go
@@ -1,5 +1,17 @@
 package model
 
+type Attributes []*Attribute
+
+func (a Attributes) GetAttribute(key string) string {
+	for _, attribute := range a {
+		if attribute.Key == key {
+			return attribute.Value
+		}
+	}
+
+	return ""
+}
+
 type Attribute struct {
 	ID    int    `json:"-" gorm:"primarykey"`
 	Key   string `json:"key" gorm:"column:key_name"`

--- a/backend/internal/entity/model/principal.go
+++ b/backend/internal/entity/model/principal.go
@@ -8,12 +8,12 @@ import (
 )
 
 type Principal struct {
-	ID         string       `json:"id" gorm:"primarykey"`
-	Roles      []*Role      `json:"roles,omitempty" gorm:"many2many:authz_principals_roles;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
-	Attributes []*Attribute `json:"attributes,omitempty" gorm:"many2many:authz_principals_attributes;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
-	IsLocked   bool         `json:"is_locked" gorm:"is_locked"`
-	CreatedAt  time.Time    `json:"created_at"`
-	UpdatedAt  time.Time    `json:"updated_at"`
+	ID         string     `json:"id" gorm:"primarykey"`
+	Roles      []*Role    `json:"roles,omitempty" gorm:"many2many:authz_principals_roles;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	Attributes Attributes `json:"attributes,omitempty" gorm:"many2many:authz_principals_attributes;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	IsLocked   bool       `json:"is_locked" gorm:"is_locked"`
+	CreatedAt  time.Time  `json:"created_at"`
+	UpdatedAt  time.Time  `json:"updated_at"`
 }
 
 func (Principal) TableName() string {

--- a/backend/internal/entity/model/resource.go
+++ b/backend/internal/entity/model/resource.go
@@ -5,25 +5,15 @@ import (
 )
 
 type Resource struct {
-	ID         string       `json:"id" gorm:"primarykey"`
-	Kind       string       `json:"kind" gorm:"kind"`
-	Value      string       `json:"value" gorm:"value"`
-	Attributes []*Attribute `json:"attributes,omitempty" gorm:"many2many:authz_resources_attributes;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
-	IsLocked   bool         `json:"is_locked" gorm:"is_locked"`
-	CreatedAt  time.Time    `json:"created_at"`
-	UpdatedAt  time.Time    `json:"updated_at"`
+	ID         string     `json:"id" gorm:"primarykey"`
+	Kind       string     `json:"kind" gorm:"kind"`
+	Value      string     `json:"value" gorm:"value"`
+	Attributes Attributes `json:"attributes,omitempty" gorm:"many2many:authz_resources_attributes;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	IsLocked   bool       `json:"is_locked" gorm:"is_locked"`
+	CreatedAt  time.Time  `json:"created_at"`
+	UpdatedAt  time.Time  `json:"updated_at"`
 }
 
 func (Resource) TableName() string {
 	return "authz_resources"
-}
-
-func (r *Resource) GetAttribute(key string) string {
-	for _, attribute := range r.Attributes {
-		if attribute.Key == key {
-			return attribute.Value
-		}
-	}
-
-	return ""
 }

--- a/docs/model/abac.md
+++ b/docs/model/abac.md
@@ -15,6 +15,10 @@ First, you can check for both resource and principal attribute names:
 ```
 resource.<attribute_name> == principal.<attribute_name>
 resource.<attribute_name> != principal.<attribute_name>
+resource.<attribute_name> > principal.<attribute_name>
+resource.<attribute_name> >= principal.<attribute_name>
+resource.<attribute_name> < principal.<attribute_name>
+resource.<attribute_name> <= principal.<attribute_name>
 ```
 
 Or, you can check for a specific value of a resource attribute:
@@ -22,6 +26,10 @@ Or, you can check for a specific value of a resource attribute:
 ```
 resource.<attribute_name> == <a value>
 resource.<attribute_name> != <a value>
+resource.<attribute_name> > <a numeric value>
+resource.<attribute_name> >= <a numeric value>
+resource.<attribute_name> < <a numeric value>
+resource.<attribute_name> <= <a numeric value>
 ```
 
 Or, you can check for a specific value of a principal attribute:
@@ -29,6 +37,10 @@ Or, you can check for a specific value of a principal attribute:
 ```
 principal.<attribute_name> == <a value>
 principal.<attribute_name> != <a value>
+principal.<attribute_name> > <a numeric value>
+principal.<attribute_name> >= <a numeric value>
+principal.<attribute_name> < <a numeric value>
+principal.<attribute_name> <= <a numeric value>
 ```
 
 ## Blog post example


### PR DESCRIPTION
## Feature

Policies attribute rules can actually support `==` (equal) and `!=` (not equal) operators only.

This pull request adds support of numeric `>` (greater), `<` (lower), `>=` (greater equal) and `<=` (lower equal) rule operators.

For instance, this could allow to create this kind of policy attribute rule:

```bash
resource.words_number >= 100
```

- [X] Add rule operators behaviors
- [x] Add unit and functional tests
- [x] Update documentation with these new operators